### PR TITLE
ci: migrate to ruff

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -81,7 +81,7 @@ async def deploy_on_device(hostname: str, credentials: Dict) -> bool:
     # Try to connect with one user in the list
     for user, password in credentials.items():
         if user.endswith(DEFAULT_PASSWORD_SUFFIX):
-            user = user[: -len(DEFAULT_PASSWORD_SUFFIX)]
+            user = user[: -len(DEFAULT_PASSWORD_SUFFIX)]  # noqa: PLW2901
 
         try:
             await device.connect(user, password)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,36 @@
+[tool.ruff]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "C",     # flake8-comprehensions
+    "B",     # flake8-bugbear
+    "ASYNC", # flake8-async
+    "C4",    # flake8-comprehensions
+    "G",     # flake8-logging-format
+    "PL",     # pylint
+]
+ignore = [
+    "E501",     # line too long, handled by black
+    "C901",     # function is too complex
+    "PLR2004",  # magic value used in comparison
+    "PLR1711",  # useless `return` statement at end of function
+    "PLC1901",  # compare-to-empty-string
+    "PLR0911",  # too many return statements
+    "PLR0912",  # too many branches
+    "PLR0915",  # too many statements
+    "B009",     # do not call getattr with a constant attribute value
+    "B904",     # raise without from inside except
+]
+line-length = 100
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/*.py" = ["PL"]
+
+[tool.mypy]
+ignore_missing_imports = true
+
 [tool.black]
 line-length = 100
 exclude = '''

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,9 +3,6 @@ coverage
 invoke
 isort
 mypy
-pydocstyle < 6.2
-pylama
-pylint
 pytest
 pytest-benchmark
 pytest-mock
@@ -13,3 +10,4 @@ setuptools
 six
 tox
 types-requests
+ruff

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,9 @@ commands =
 
 # Linter environment
 [testenv:lint]
+allowlist_externals = ruff
 commands =
-  pylama --skip '.venv/*,venv/*,.tox/*,.vscode/*,build/*'
+  ruff .
   black --check .
   isort --check --diff .
 
@@ -28,7 +29,7 @@ deps =
 [testenv:bundle]
 basepython = {env:PYTHON:python}
 deps = pex
-whitelist_external = echo
+allowlist_externals = echo
 commands =
   # Creates a source archive in sdist/.
   {envpython} setup.py sdist --dist-dir=sdist --format=gztar


### PR DESCRIPTION
Migrating to Ruff instead of Pylama.

Pylama seems unmaintained for a year now, and is incompatible with latest pydocstyle.
Ruff is also blazzing fast!