### PR TITLE
ci: separate lint and test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Running checks with Tox
+      - name: Run linters
         run: |
-          tox
+          tox -e lint
+      - name: Run tests
+        run: |
+          tox -e test
 
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The goal of this commit is to be able to spot issues easier.

Before this commit, all the checks are run at once in the "Running checks with Tox".

With this commit, lint and test will be in two separate step.